### PR TITLE
[도메인 설계]

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/domain/AuditingFields.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/domain/AuditingFields.java
@@ -1,0 +1,45 @@
+package com.fastcampus.projectboardadmin.domain;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class AuditingFields {
+
+    /** 생성일시 */
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+
+    /** 생성자 */
+    @CreatedBy
+    @Column(nullable = false, updatable = false, length = 100)
+    protected String createdBy;
+
+    /** 수정일시 */
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    protected LocalDateTime modifiedAt;
+
+    /** 수정자 */
+    @LastModifiedBy
+    @Column(nullable = false, length = 100)
+    protected String modifiedBy;
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/domain/UserAccount.java
@@ -1,0 +1,88 @@
+package com.fastcampus.projectboardadmin.domain;
+
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import com.fastcampus.projectboardadmin.domain.converter.RoleTypesConverter;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Getter
+@ToString(callSuper = true)
+@Table(indexes = {
+        @Index(columnList = "email", unique = true),
+        @Index(columnList = "createdAt"),
+        @Index(columnList = "createdBy")
+})
+@Entity
+public class UserAccount extends AuditingFields {
+    @Id
+    @Column(length = 50)
+    private String userId;
+
+    @Setter @Column(nullable = false) private String userPassword;
+
+    /**[도메인 설계] - RoleTypesConverter*/
+    //엔티티로 만들어 연관관계 매핑을 해줄 수 있으나,
+    //1,2,3 방식의 String 타입으로 DB에 저장 후, 콤마를 기준으로 DB 에서 꺼내 쓰는 방식
+    //spring 한테 roleTypes 가 필드가 맞고, DB 에 넘길 때는 Set을 통으로 String 방식으로 줄 것임을 알려주기 위해
+    //RoleTypesConverter 필요
+    @Convert(converter = RoleTypesConverter.class)
+    @Column(nullable = false)
+    private Set<RoleType> roleTypes = new LinkedHashSet<>();
+
+    @Setter @Column(length = 100) private String email;
+    @Setter @Column(length = 100) private String nickname;
+    @Setter private String memo;
+
+    protected UserAccount() {}
+
+    private UserAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+        this.userId = userId;
+        this.userPassword = userPassword;
+        this.roleTypes = roleTypes;
+        this.email = email;
+        this.nickname = nickname;
+        this.memo = memo;
+        this.createdBy = createdBy;
+        this.modifiedBy = createdBy;
+    }
+
+    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return UserAccount.of(userId, userPassword, roleTypes, email, nickname, memo, null);
+    }
+
+    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+        return new UserAccount(userId, userPassword, roleTypes, email, nickname, memo, createdBy);
+    }
+
+    public void addRoleType(RoleType roleType) {
+        this.getRoleTypes().add(roleType);
+    }
+
+    public void addRoleTypes(Collection<RoleType> roleTypes) {
+        this.getRoleTypes().addAll(roleTypes);
+    }
+
+    public void removeRoleType(RoleType roleType) {
+        this.getRoleTypes().remove(roleType);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserAccount that)) return false;
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getUserId());
+    }
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/domain/constant/RoleType.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/domain/constant/RoleType.java
@@ -1,0 +1,17 @@
+package com.fastcampus.projectboardadmin.domain.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum RoleType {
+
+    USER("ROLE_USER"),
+    MANAGER("ROLE_MANAGER"),
+    DEVELOPER("ROLE_DEVELOPER"),
+    ADMIN("ROLE_ADMIN")
+    ;
+
+    @Getter private final String roleName;
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/domain/converter/RoleTypesConverter.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/domain/converter/RoleTypesConverter.java
@@ -1,0 +1,33 @@
+package com.fastcampus.projectboardadmin.domain.converter;
+
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**[도메인 설계] - RoleTypesConverter*/
+//Set<RoleType>을 String 으로 convert
+@Converter
+public class RoleTypesConverter implements AttributeConverter<Set<RoleType>, String> {
+
+    //구분자
+    private static final String DELIMITER = ",";
+
+    //엔티티를 DB에 저장할 때 , Set<RoleType> -> String
+    @Override
+    public String convertToDatabaseColumn(Set<RoleType> attribute) {
+        //attribute 에서 뽑아낸 RoleType 의 이름(String)들을 정렬 후, 콤마를 이용해 하나의 문자열로 조인한다.
+        return attribute.stream().map(RoleType::name).sorted().collect(Collectors.joining(DELIMITER));
+    }
+
+    //DB에 있던 값을 엔티티로 , String -> Set<RoleType>
+    @Override
+    public Set<RoleType> convertToEntityAttribute(String dbData) {
+        //dbData 을 콤마 기준으로 쪼개고, RoleType 으로 변환해 Set 으로 전환
+        return Arrays.stream(dbData.split(DELIMITER)).map(RoleType::valueOf).collect(Collectors.toSet());
+    }
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
@@ -1,0 +1,56 @@
+package com.fastcampus.projectboardadmin.dto;
+
+import com.fastcampus.projectboardadmin.domain.UserAccount;
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record UserAccountDto(
+        String userId,
+        String userPassword,
+        Set<RoleType> roleTypes,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return UserAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    }
+
+    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new UserAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static UserAccountDto from(UserAccount entity) {
+        return new UserAccountDto(
+                entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getRoleTypes(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getMemo(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public UserAccount toEntity() {
+        return UserAccount.of(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo
+        );
+    }
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
@@ -1,0 +1,84 @@
+package com.fastcampus.projectboardadmin.dto.security;
+
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record BoardAdminPrincipal(
+        String username,
+        String password,
+        Collection<? extends GrantedAuthority> authorities,
+        String email,
+        String nickname,
+        String memo,
+        Map<String, Object> oAuth2Attributes
+) implements UserDetails, OAuth2User {
+
+    public static BoardAdminPrincipal of(String username, String password, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return BoardAdminPrincipal.of(username, password, roleTypes, email, nickname, memo, Map.of());
+    }
+
+    public static BoardAdminPrincipal of(String username, String password, Set<RoleType> roleTypes, String email, String nickname, String memo, Map<String, Object> oAuth2Attributes) {
+        return new BoardAdminPrincipal(
+                username,
+                password,
+                roleTypes.stream()
+                        .map(RoleType::getRoleName)
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toUnmodifiableSet())
+                ,
+                email,
+                nickname,
+                memo,
+                oAuth2Attributes
+        );
+    }
+
+    public static BoardAdminPrincipal from(UserAccountDto dto) {
+        return BoardAdminPrincipal.of(
+                dto.userId(),
+                dto.userPassword(),
+                dto.roleTypes(),
+                dto.email(),
+                dto.nickname(),
+                dto.memo()
+        );
+    }
+
+    public UserAccountDto toDto() {
+        return UserAccountDto.of(
+                username,
+                password,
+                authorities.stream()
+                        .map(GrantedAuthority::getAuthority)
+                        .map(RoleType::valueOf)
+                        .collect(Collectors.toUnmodifiableSet())
+                ,
+                email,
+                nickname,
+                memo
+        );
+    }
+
+
+    @Override public String getUsername() { return username; }
+    @Override public String getPassword() { return password; }
+    @Override public Collection<? extends GrantedAuthority> getAuthorities() { return authorities; }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+
+    @Override public Map<String, Object> getAttributes() { return oAuth2Attributes; }
+    @Override public String getName() { return username; }
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/security/KakaoOAuth2Response.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/security/KakaoOAuth2Response.java
@@ -1,0 +1,59 @@
+package com.fastcampus.projectboardadmin.dto.security;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+@SuppressWarnings("unchecked") // TODO: Map -> Object 변환 로직이 있어 제네릭 타입 캐스팅 문제를 무시한다. 더 좋은 방법이 있다면 고려할 수 있음.
+public record KakaoOAuth2Response(
+        Long id,
+        LocalDateTime connectedAt,
+        Map<String, Object> properties,
+        KakaoAccount kakaoAccount
+) {
+    public record KakaoAccount(
+            Boolean profileNicknameNeedsAgreement,
+            Profile profile,
+            Boolean hasEmail,
+            Boolean emailNeedsAgreement,
+            Boolean isEmailValid,
+            Boolean isEmailVerified,
+            String email
+    ) {
+        public record Profile(String nickname) {
+            public static Profile from(Map<String, Object> attributes) {
+                return new Profile(String.valueOf(attributes.get("nickname")));
+            }
+        }
+
+        public static KakaoAccount from(Map<String, Object> attributes) {
+            return new KakaoAccount(
+                    Boolean.valueOf(String.valueOf(attributes.get("profile_nickname_needs_agreement"))),
+                    Profile.from((Map<String, Object>) attributes.get("profile")),
+                    Boolean.valueOf(String.valueOf(attributes.get("has_email"))),
+                    Boolean.valueOf(String.valueOf(attributes.get("email_needs_agreement"))),
+                    Boolean.valueOf(String.valueOf(attributes.get("is_email_valid"))),
+                    Boolean.valueOf(String.valueOf(attributes.get("is_email_verified"))),
+                    String.valueOf(attributes.get("email"))
+            );
+        }
+
+        public String nickname() { return this.profile().nickname(); }
+    }
+
+    public static KakaoOAuth2Response from(Map<String, Object> attributes) {
+        return new KakaoOAuth2Response(
+                Long.valueOf(String.valueOf(attributes.get("id"))),
+                LocalDateTime.parse(
+                        String.valueOf(attributes.get("connected_at")),
+                        DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.systemDefault())
+                ),
+                (Map<String, Object>) attributes.get("properties"),
+                KakaoAccount.from((Map<String, Object>) attributes.get("kakao_account"))
+        );
+    }
+
+    public String email() { return this.kakaoAccount().email(); }
+    public String nickname() { return this.kakaoAccount().nickname(); }
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/dto/security/KakaoOAuth2ResponseTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/dto/security/KakaoOAuth2ResponseTest.java
@@ -1,0 +1,60 @@
+package com.fastcampus.projectboardadmin.dto.security;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("DTO - Kakao OAuth 2.0 인증 응답 데이터 테스트")
+class KakaoOAuth2ResponseTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @DisplayName("인증 결과를 Map(deserialized json)으로 받으면, 카카오 인증 응답 객체로 변환한다.")
+    @Test
+    void givenMapFromJson_whenInstantiating_thenReturnsKakaoResponseObject() throws Exception {
+        // Given
+        String serializedResponse = """
+                {
+                    "id": 1234567890,
+                    "connected_at": "2022-01-02T00:12:34Z",
+                    "properties": {
+                        "nickname": "홍길동"
+                    },
+                    "kakao_account": {
+                        "profile_nickname_needs_agreement": false,
+                        "profile": {
+                            "nickname": "홍길동"
+                        },
+                        "has_email": true,
+                        "email_needs_agreement": false,
+                        "is_email_valid": true,
+                        "is_email_verified": true,
+                        "email": "test@gmail.com"
+                    }
+                }
+                """;
+        Map<String, Object> attributes = mapper.readValue(serializedResponse, new TypeReference<>() {});
+
+        // When
+        KakaoOAuth2Response result = KakaoOAuth2Response.from(attributes);
+
+        // Then
+        assertThat(result)
+                .hasFieldOrPropertyWithValue("id", 1234567890L)
+                .hasFieldOrPropertyWithValue("connectedAt", ZonedDateTime.of(2022, 1, 2, 0, 12, 34, 0, ZoneOffset.UTC)
+                        .withZoneSameInstant(ZoneId.systemDefault())
+                        .toLocalDateTime()
+                )
+                .hasFieldOrPropertyWithValue("kakaoAccount.profile.nickname", "홍길동")
+                .hasFieldOrPropertyWithValue("kakaoAccount.email", "test@gmail.com");
+    }
+
+}


### PR DESCRIPTION
어드민 서비스의 기본 도메인을 설계했다.
- `UserAccount`
- `UserAccountDto`
- `RoleType`
- `RoleTypeConverter`
- `BoardAdminPrincipal`
- `KakaoOAuth2Response`
- `KakoOAuth2ResponseTest`

이전 게시판 서비스와 달리
`RoleType` , `RoleTypeConverter` 가 추가 되었다.