### PR TITLE
[Refactoring] - 어드민 회원 테이블명 변경

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/domain/AdminAccount.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/domain/AdminAccount.java
@@ -20,7 +20,7 @@ import java.util.Set;
         @Index(columnList = "createdBy")
 })
 @Entity
-public class UserAccount extends AuditingFields {
+public class AdminAccount extends AuditingFields {
     @Id
     @Column(length = 50)
     private String userId;
@@ -40,9 +40,9 @@ public class UserAccount extends AuditingFields {
     @Setter @Column(length = 100) private String nickname;
     @Setter private String memo;
 
-    protected UserAccount() {}
+    protected AdminAccount() {}
 
-    private UserAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+    private AdminAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
         this.userId = userId;
         this.userPassword = userPassword;
         this.roleTypes = roleTypes;
@@ -53,12 +53,12 @@ public class UserAccount extends AuditingFields {
         this.modifiedBy = createdBy;
     }
 
-    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-        return UserAccount.of(userId, userPassword, roleTypes, email, nickname, memo, null);
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return AdminAccount.of(userId, userPassword, roleTypes, email, nickname, memo, null);
     }
 
-    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
-        return new UserAccount(userId, userPassword, roleTypes, email, nickname, memo, createdBy);
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+        return new AdminAccount(userId, userPassword, roleTypes, email, nickname, memo, createdBy);
     }
 
     public void addRoleType(RoleType roleType) {
@@ -76,7 +76,7 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount that)) return false;
+        if (!(o instanceof AdminAccount that)) return false;
         return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
@@ -1,0 +1,56 @@
+package com.fastcampus.projectboardadmin.dto;
+
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record AdminAccountDto(
+        String userId,
+        String userPassword,
+        Set<RoleType> roleTypes,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return AdminAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    }
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new AdminAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static AdminAccountDto from(AdminAccount entity) {
+        return new AdminAccountDto(
+                entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getRoleTypes(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getMemo(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public AdminAccount toEntity() {
+        return AdminAccount.of(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo
+        );
+    }
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
@@ -1,6 +1,6 @@
 package com.fastcampus.projectboardadmin.dto;
 
-import com.fastcampus.projectboardadmin.domain.UserAccount;
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 
 import java.time.LocalDateTime;
@@ -8,7 +8,6 @@ import java.util.Set;
 
 public record UserAccountDto(
         String userId,
-        String userPassword,
         Set<RoleType> roleTypes,
         String email,
         String nickname,
@@ -18,39 +17,11 @@ public record UserAccountDto(
         LocalDateTime modifiedAt,
         String modifiedBy
 ) {
-
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-        return UserAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return UserAccountDto.of(userId, roleTypes, email, nickname, memo, null, null, null, null);
     }
 
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
-        return new UserAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new UserAccountDto(userId, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
     }
-
-    public static UserAccountDto from(UserAccount entity) {
-        return new UserAccountDto(
-                entity.getUserId(),
-                entity.getUserPassword(),
-                entity.getRoleTypes(),
-                entity.getEmail(),
-                entity.getNickname(),
-                entity.getMemo(),
-                entity.getCreatedAt(),
-                entity.getCreatedBy(),
-                entity.getModifiedAt(),
-                entity.getModifiedBy()
-        );
-    }
-
-    public UserAccount toEntity() {
-        return UserAccount.of(
-                userId,
-                userPassword,
-                roleTypes,
-                email,
-                nickname,
-                memo
-        );
-    }
-
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
@@ -1,17 +1,15 @@
 package com.fastcampus.projectboardadmin.dto.security;
 
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
-import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 public record BoardAdminPrincipal(
         String username,
         String password,
@@ -21,11 +19,9 @@ public record BoardAdminPrincipal(
         String memo,
         Map<String, Object> oAuth2Attributes
 ) implements UserDetails, OAuth2User {
-
     public static BoardAdminPrincipal of(String username, String password, Set<RoleType> roleTypes, String email, String nickname, String memo) {
         return BoardAdminPrincipal.of(username, password, roleTypes, email, nickname, memo, Map.of());
     }
-
     public static BoardAdminPrincipal of(String username, String password, Set<RoleType> roleTypes, String email, String nickname, String memo, Map<String, Object> oAuth2Attributes) {
         return new BoardAdminPrincipal(
                 username,
@@ -42,7 +38,7 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public static BoardAdminPrincipal from(UserAccountDto dto) {
+    public static BoardAdminPrincipal from(AdminAccountDto dto) {
         return BoardAdminPrincipal.of(
                 dto.userId(),
                 dto.userPassword(),
@@ -53,8 +49,8 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public UserAccountDto toDto() {
-        return UserAccountDto.of(
+    public AdminAccountDto toDto() {
+        return AdminAccountDto.of(
                 username,
                 password,
                 authorities.stream()
@@ -67,18 +63,13 @@ public record BoardAdminPrincipal(
                 memo
         );
     }
-
-
     @Override public String getUsername() { return username; }
     @Override public String getPassword() { return password; }
     @Override public Collection<? extends GrantedAuthority> getAuthorities() { return authorities; }
-
     @Override public boolean isAccountNonExpired() { return true; }
     @Override public boolean isAccountNonLocked() { return true; }
     @Override public boolean isCredentialsNonExpired() { return true; }
     @Override public boolean isEnabled() { return true; }
-
     @Override public Map<String, Object> getAttributes() { return oAuth2Attributes; }
     @Override public String getName() { return username; }
-
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/repository/AdminAccountRepository.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/repository/AdminAccountRepository.java
@@ -1,0 +1,7 @@
+package com.fastcampus.projectboardadmin.repository;
+
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminAccountRepository extends JpaRepository<AdminAccount, String> {
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
@@ -1,7 +1,0 @@
-package com.fastcampus.projectboardadmin.repository;
-
-import com.fastcampus.projectboardadmin.domain.UserAccount;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
-}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,6 +1,6 @@
 -- 테스트 계정
 -- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
-insert into user_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
+insert into admin_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
                             ('uno', '{noop}asdf1234', 'ADMIN', 'Uno', 'uno@mail.com', 'I am Uno.', now(), 'uno', now(), 'uno'),
                             ('mark', '{noop}asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'uno', now(), 'uno'),
                             ('susan', '{noop}asdf1234', 'MANAGER,DEVELOPER', 'Susan', 'Susan@mail.com', 'I am Susan.', now(), 'uno', now(), 'uno'),

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -105,7 +105,6 @@ class ArticleCommentManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -106,7 +106,6 @@ class ArticleManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",

--- a/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.fastcampus.projectboardadmin.repository;
 
-import com.fastcampus.projectboardadmin.domain.UserAccount;
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,10 +23,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 class JpaRepositoryTest {
 
-    private final UserAccountRepository userAccountRepository;
+    private final AdminAccountRepository adminAccountRepository;
 
-    public JpaRepositoryTest(@Autowired UserAccountRepository userAccountRepository) {
-        this.userAccountRepository = userAccountRepository;
+    public JpaRepositoryTest(@Autowired AdminAccountRepository adminAccountRepository) {
+        this.adminAccountRepository = adminAccountRepository;
     }
 
     @DisplayName("select 테스트")
@@ -35,10 +35,10 @@ class JpaRepositoryTest {
         // Given
 
         // When
-        List<UserAccount> userAccounts = userAccountRepository.findAll();
+        List<AdminAccount> adminAccounts = adminAccountRepository.findAll();
 
         // Then
-        assertThat(userAccounts)
+        assertThat(adminAccounts)
                 .isNotNull()
                 .hasSize(4);
     }
@@ -47,27 +47,27 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccount_whenInserting_thenWorksFine() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = UserAccount.of("test", "pw", Set.of(RoleType.DEVELOPER), null, null, null);
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = AdminAccount.of("test", "pw", Set.of(RoleType.DEVELOPER), null, null, null);
 
         // When
-        userAccountRepository.save(userAccount);
+        adminAccountRepository.save(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count()).isEqualTo(previousCount + 1);
+        assertThat(adminAccountRepository.count()).isEqualTo(previousCount + 1);
     }
 
     @DisplayName("update 테스트")
     @Test
     void givenUserAccountAndRoleType_whenUpdating_thenWorksFine() {
         // Given
-        UserAccount userAccount = userAccountRepository.getReferenceById("uno");
-        userAccount.addRoleType(RoleType.DEVELOPER);
-        userAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
-        userAccount.removeRoleType(RoleType.ADMIN);
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("uno");
+        adminAccount.addRoleType(RoleType.DEVELOPER);
+        adminAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
+        adminAccount.removeRoleType(RoleType.ADMIN);
 
         // When
-        UserAccount updatedAccount = userAccountRepository.saveAndFlush(userAccount);
+        AdminAccount updatedAccount = adminAccountRepository.saveAndFlush(adminAccount);
 
         // Then
         assertThat(updatedAccount)
@@ -79,14 +79,14 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccount_whenDeleting_thenWorksFine() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = userAccountRepository.getReferenceById("uno");
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("uno");
 
         // When
-        userAccountRepository.delete(userAccount);
+        adminAccountRepository.delete(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count()).isEqualTo(previousCount - 1);
+        assertThat(adminAccountRepository.count()).isEqualTo(previousCount - 1);
     }
 
 

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
@@ -171,7 +171,6 @@ class ArticleCommentManagementServiceTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
@@ -170,7 +170,6 @@ class ArticleManagementServiceTest {
         private UserAccountDto createUserAccountDto() {
             return UserAccountDto.of(
                     "unoTest",
-                    "pw",
                     Set.of(RoleType.ADMIN),
                     "uno-test@email.com",
                     "uno-test",


### PR DESCRIPTION
`user_account` -> `admin_account`로 어드민 회원 테이블명 변경. 
통신하려는 게시판 서비스의 회원 도메인명과 이름이 겹친다.

`UserAccount` 가 사용된 곳을 모두 바꾸어 주었다.