### PR TITLE
[Development] - 회원 관리 기능 구현

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementController.java
@@ -1,22 +1,43 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import com.fastcampus.projectboardadmin.dto.response.UserAccountResponse;
+import com.fastcampus.projectboardadmin.service.UserAccountManagementService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
+@RequiredArgsConstructor
 @RequestMapping("/management/user-accounts")
 @Controller
 public class UserAccountManagementController {
 
+    private final UserAccountManagementService userAccountManagementService;
+
     @GetMapping
-    public String userAccounts(
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
-            Model model
-    ) {
+    public String userAccounts(Model model) {
+        model.addAttribute(
+                "userAccounts",
+                userAccountManagementService.getUserAccounts().stream().map(UserAccountResponse::from).toList()
+        );
+
         return "management/user-accounts";
     }
+
+    @ResponseBody
+    @GetMapping("/{userId}")
+    public UserAccountResponse userAccount(@PathVariable String userId) {
+        return UserAccountResponse.from(userAccountManagementService.getUserAccount(userId));
+    }
+
+    @PostMapping("/{userId}")
+    public String deleteUserAccount(@PathVariable String userId) {
+        userAccountManagementService.deleteUserAccount(userId);
+
+        return "redirect:/management/user-accounts";
+    }
+
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/response/UserAccountResponse.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/response/UserAccountResponse.java
@@ -1,0 +1,31 @@
+package com.fastcampus.projectboardadmin.dto.response;
+
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+
+import java.time.LocalDateTime;
+
+public record UserAccountResponse(
+        String userId,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy
+) {
+
+    public static UserAccountResponse of(String userId, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy) {
+        return new UserAccountResponse(userId, email, nickname, memo, createdAt, createdBy);
+    }
+
+    public static UserAccountResponse from(UserAccountDto dto) {
+        return UserAccountResponse.of(
+                dto.userId(),
+                dto.email(),
+                dto.nickname(),
+                dto.memo(),
+                dto.createdAt(),
+                dto.createdBy()
+        );
+    }
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementService.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementService.java
@@ -32,6 +32,7 @@ public class ArticleCommentManagementService {
 
     public ArticleCommentDto getArticleComment(Long articleCommentId) {
         URI uri = UriComponentsBuilder.fromHttpUrl(projectProperties.board().url() + "/api/articleComments/" + articleCommentId)
+                .queryParam("projection", "withUserAccount")
                 .build()
                 .toUri();
         ArticleCommentDto response = restTemplate.getForObject(uri, ArticleCommentDto.class);

--- a/src/main/java/com/fastcampus/projectboardadmin/service/ArticleManagementService.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/service/ArticleManagementService.java
@@ -32,6 +32,7 @@ public class ArticleManagementService {
 
     public ArticleDto getArticle(Long articleId) {
         URI uri = UriComponentsBuilder.fromHttpUrl(projectProperties.board().url() + "/api/articles/" + articleId)
+                .queryParam("projection", "withUserAccount")
                 .build()
                 .toUri();
         ArticleDto response = restTemplate.getForObject(uri, ArticleDto.class);

--- a/src/main/java/com/fastcampus/projectboardadmin/service/UserAccountManagementService.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/service/UserAccountManagementService.java
@@ -1,25 +1,49 @@
 package com.fastcampus.projectboardadmin.service;
 
 import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.dto.properties.ProjectProperties;
+import com.fastcampus.projectboardadmin.dto.response.UserAccountClientResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
 public class UserAccountManagementService {
 
+    private final RestTemplate restTemplate;
+    private final ProjectProperties projectProperties;
+
     public List<UserAccountDto> getUserAccounts() {
-        return List.of();
+        URI uri = UriComponentsBuilder.fromHttpUrl(projectProperties.board().url() + "/api/userAccounts")
+                .queryParam("size", 10000) // TODO: 전체 회원 목록을 가져오기 위해 충분히 큰 사이즈를 전달하는 방식. 불완전하다.
+                .build()
+                .toUri();
+        UserAccountClientResponse response = restTemplate.getForObject(uri, UserAccountClientResponse.class);
+
+        return Optional.ofNullable(response).orElseGet(UserAccountClientResponse::empty).userAccounts();
     }
 
     public UserAccountDto getUserAccount(String userId) {
-        return null;
+        URI uri = UriComponentsBuilder.fromHttpUrl(projectProperties.board().url() + "/api/userAccounts/" + userId)
+                .build()
+                .toUri();
+        UserAccountDto response = restTemplate.getForObject(uri, UserAccountDto.class);
+
+        return Optional.ofNullable(response)
+                .orElseThrow(() -> new NoSuchElementException("게시글이 없습니다 - userId: " + userId));
     }
 
     public void deleteUserAccount(String userId) {
-
+        URI uri = UriComponentsBuilder.fromHttpUrl(projectProperties.board().url() + "/api/userAccounts/" + userId)
+                .build()
+                .toUri();
+        restTemplate.delete(uri);
     }
-
 }

--- a/src/main/resources/templates/management/user-accounts.html
+++ b/src/main/resources/templates/management/user-accounts.html
@@ -28,7 +28,7 @@
             </thead>
             <tbody>
             <tr>
-                <td>uno</td>
+                <td><a data-toggle="modal" data-target="#layout-modal">uno</a></td>
                 <td>Uno</td>
                 <td>uno@email.com</td>
                 <td>This is memo.</td>
@@ -54,6 +54,9 @@
     <footer id="layout-footer">푸터 삽입부</footer>
 </div>
 
+<div class="modal fade" id="layout-modal"></div>
+<!-- /.modal -->
+
 <!--/* REQUIRED SCRIPTS */-->
 <script id="layout-scripts">/* 공통 스크립트 삽입부 */</script>
 
@@ -77,6 +80,30 @@
             "buttons": ["copy", "csv", "excel", "pdf", "print", "colvis"],
             "pageLength": 10
         }).buttons().container().appendTo('#main-table_wrapper .col-md-6:eq(0)'); // main-table_wrapper ID는 플러그인에 의해 자동 생성됨
+    });
+</script>
+<script>
+    $(document).ready(() => {
+        $('#layout-modal').on('show.bs.modal', (event) => {
+            console.log($(event.relatedTarget))
+            const userId = $(event.relatedTarget).data('id');
+
+            fetch(`/management/user-accounts/${userId}`)
+                .then(response => response.json())
+                .then(data => {
+                    const bodyText =
+                        "- 닉네임: " + data.nickname + "\n" +
+                        "- 이메일: " + data.email + "\n" +
+                        "- 메모: " + data.memo;
+
+                    $('.modal-title').text(data.nickname);
+                    $('.modal-body pre').text(bodyText);
+                    $('.modal-footer form').attr('action', `/management/user-accounts/${userId}`);
+                })
+                .catch(error => {
+                    console.error('회원 정보 로딩 실패: ', error);
+                });
+        });
     });
 </script>
 </body>

--- a/src/main/resources/templates/management/user-accounts.th.xml
+++ b/src/main/resources/templates/management/user-accounts.th.xml
@@ -4,7 +4,30 @@
     <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
     <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
     <attr sel="#layout-main" th:replace="layouts/layout-main-table :: common_main_table('회원 관리', (~{::#main-table} ?: ~{}))" />
+    <attr sel="#layout-modal" th:replace="layouts/layout-main-table-modal :: .modal" />
     <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
     <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
     <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+
+    <attr sel="#main-table">
+        <attr sel="thead/tr">
+            <attr sel="th[0]" th:text="'유저 ID'" />
+            <attr sel="th[1]" th:text="'닉네임'" />
+            <attr sel="th[2]" th:text="'이메일'" />
+            <attr sel="th[3]" th:text="'메모'" />
+            <attr sel="th[4]" th:text="'작성자'" />
+            <attr sel="th[5]" th:text="'작성일시'" />
+        </attr>
+
+        <attr sel="tbody" th:remove="all-but-first">
+            <attr sel="tr[0]" th:each="userAccount : ${userAccounts}">
+                <attr sel="td[0]/a" th:text="${userAccount.userId}" th:href="@{#}" th:data-id="${userAccount.userId}" />
+                <attr sel="td[1]" th:text="${userAccount.nickname}" />
+                <attr sel="td[2]" th:text="${userAccount.email}" />
+                <attr sel="td[3]" th:text="${userAccount.memo}" />
+                <attr sel="td[4]" th:text="${userAccount.createdBy}" />
+                <attr sel="td[5]/time" th:datetime="${userAccount.createdAt}" th:text="${#temporals.format(userAccount.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
+            </attr>
+        </attr>
+    </attr>
 </thlogic>

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -34,6 +35,8 @@ class UserAccountManagementControllerTest {
     public UserAccountManagementControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
     }
+
+    @WithMockUser(username = "tester", roles = "USER")
     @DisplayName("[view][GET] 회원 관리 페이지 - 정상 호출")
     @Test
     void givenNothing_whenRequestingUserAccountManagementView_thenReturnsUserAccountManagementView() throws Exception {
@@ -49,6 +52,7 @@ class UserAccountManagementControllerTest {
         then(userAccountManagementService).should().getUserAccounts();
     }
 
+    @WithMockUser(username = "tester", roles = "USER")
     @DisplayName("[data][GET] 회원 1개 - 정상 호출")
     @Test
     void givenUserAccountId_whenRequestingUserAccount_thenReturnsUserAccount() throws Exception {
@@ -65,6 +69,8 @@ class UserAccountManagementControllerTest {
                 .andExpect(jsonPath("$.nickname").value(userAccountDto.nickname()));
         then(userAccountManagementService).should().getUserAccount(userId);
     }
+
+    @WithMockUser(username = "tester", roles = "MANAGER")
 
     @DisplayName("[view][POST] 회원 삭제 - 정상 호출")
     @Test

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
@@ -118,7 +118,7 @@ class ArticleCommentManagementServiceTest {
             Long articleCommentId = 1L;
             ArticleCommentDto expectedComment = createArticleCommentDto("댓글");
             server
-                    .expect(requestTo(projectProperties.board().url() + "/api/articleComments/" + articleCommentId))
+                    .expect(requestTo(projectProperties.board().url() + "/api/articleComments/" + articleCommentId + "?projection=withUserAccount"))
                     .andRespond(withSuccess(
                             mapper.writeValueAsString(expectedComment),
                             MediaType.APPLICATION_JSON

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
@@ -116,7 +116,7 @@ class ArticleManagementServiceTest {
             Long articleId = 1L;
             ArticleDto expectedArticle = createArticleDto("게시판", "글");
             server
-                    .expect(requestTo(projectProperties.board().url() + "/api/articles/" + articleId))
+                    .expect(requestTo(projectProperties.board().url() + "/api/articles/" + articleId + "?projection=withUserAccount"))
                     .andRespond(withSuccess(
                             mapper.writeValueAsString(expectedArticle),
                             MediaType.APPLICATION_JSON


### PR DESCRIPTION
회원 관리 기능에 따른

컨트롤러
서비스
뷰
들을 구현했다.

특히, 서비스에서

지난 강의에서 게시글, 댓글 데이터를 `RestTemplate`으로 요청할 때,
회원 정보를 함께 받아오기 쉬운 형태(`withUserAccount`)로 만들기 위해
게시판 서비스 쪽에서 작업을 해주었는데, 
이를 실제로 불러올 때 필요한 projection 쿼리 파라미터를 빼먹음.

이 구현이 빠져도 문제가 없었던 이유는 단일 게시글/댓글 조회 결과를
모달 창 안에서 보는데, 회원 정보(닉네임)을 사용하지 않았기 때문.

그러나 개발 의도에 맞게끔 단건 조회에 projection 파라미터를 넣어주기로 한다.