### PR TITLE
[Development] - 로그인 기능 구현

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/controller/AdminAccountController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/AdminAccountController.java
@@ -1,17 +1,21 @@
 package com.fastcampus.projectboardadmin.controller;
 
 import com.fastcampus.projectboardadmin.dto.response.AdminAccountResponse;
+import com.fastcampus.projectboardadmin.service.AdminAccountService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@RequestMapping("/admin/members")
+@RequiredArgsConstructor
 @Controller
 public class AdminAccountController {
 
-    @GetMapping
+    private final AdminAccountService adminAccountService;
+
+    @GetMapping("/admin/members")
     public String members() {
         return "admin/members";
     }
@@ -19,12 +23,15 @@ public class AdminAccountController {
     @ResponseBody
     @GetMapping("/api/admin/members")
     public List<AdminAccountResponse> getMembers() {
-        return List.of();
+        return adminAccountService.users().stream()
+                .map(AdminAccountResponse::from)
+                .toList();
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @ResponseBody
     @DeleteMapping("/api/admin/members/{userId}")
     public void delete(@PathVariable String userId) {
+        adminAccountService.deleteUser(userId);
     }
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/service/AdminAccountService.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/service/AdminAccountService.java
@@ -1,35 +1,47 @@
 package com.fastcampus.projectboardadmin.service;
 
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
 import com.fastcampus.projectboardadmin.repository.AdminAccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class AdminAccountService {
 
     private final AdminAccountRepository adminAccountRepository;
 
+    @Transactional(readOnly = true)
     public Optional<AdminAccountDto> searchUser(String username) {
-        return Optional.empty();
+        return adminAccountRepository.findById(username)
+                .map(AdminAccountDto::from);
     }
 
     public AdminAccountDto saveUser(String username, String password, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-        return null;
+        return AdminAccountDto.from(
+                adminAccountRepository.save(
+                        AdminAccount.of(username, password, roleTypes, email, nickname, memo)
+                )
+        );
     }
 
+    @Transactional(readOnly = true)
     public List<AdminAccountDto> users() {
-        return List.of();
+        return adminAccountRepository.findAll().stream()
+                .map(AdminAccountDto::from)
+                .toList();
     }
 
     public void deleteUser(String username) {
-
+        adminAccountRepository.deleteById(username);
     }
 
 }

--- a/src/main/resources/templates/admin/members.html
+++ b/src/main/resources/templates/admin/members.html
@@ -27,7 +27,7 @@
 
 <!--/* 페이지 전용 스크립트 */-->
 <script src="/js/plugins/jsgrid/jsgrid.min.js"></script>
-<script>
+<script id="jsgrid-javascript">
     $(function () {
         $("#jsgrid-admin-members").jsGrid({
             height: "100%",

--- a/src/main/resources/templates/admin/members.th.xml
+++ b/src/main/resources/templates/admin/members.th.xml
@@ -7,4 +7,51 @@
     <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
     <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
     <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+
+    <attr sel="#jsgrid-javascript" th:utext='|
+    $(() => {
+      const csrfHeader = "${_csrf.headerName}";
+      const csrfToken = "${_csrf.token}";
+      $("#jsgrid-admin-members").jsGrid({
+        width: "100%",
+        autoload: true,
+        inserting: false,
+        editing: false,
+        sorting: true,
+        paging: false,
+        confirmDeleting: true,
+        deleteConfirm: "선택하신 어드민 계정을 삭제하시겠습니까?",
+        fields: [
+          { name: "userId", title: "유저 ID", type: "text", width: 70 },
+          { name: "nickname", title: "닉네임", type: "text", width: 60 },
+          { name: "email", title: "이메일", type: "text", width: 120 },
+          { name: "memo", title: "메모", type: "text", width: 150 },
+          { name: "roleTypes", title: "권한", type: "text", width: 100 },
+          { name: "createdBy", title: "작성자", type: "text", width: 60 },
+          { name: "createdAt", title: "작성일시", type: "text", width: 100 },
+          { type: "control" }
+        ],
+        controller: {
+          loadData: (filter) => {
+            return $.ajax({
+              type: "GET",
+              url: "/api/admin/members",
+              data: filter,
+              dataType: "json"
+            });
+          },
+          insertItem: $.noop,
+          updateItem: $.noop,
+          deleteItem: (item) => {
+            return $.ajax({
+              type: "DELETE",
+              url: "/api/admin/members/" + item.userId,
+              data: item,
+              beforeSend: (xhr) => xhr.setRequestHeader(csrfHeader, csrfToken)
+            });
+          },
+        }
+      });
+    });
+  |'/>
 </thlogic>

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/MainControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/MainControllerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -23,6 +24,7 @@ class MainControllerTest {
         this.mvc = mvc;
     }
 
+    @WithMockUser(username = "tester", roles = "USER")
     @DisplayName("[view][GET] 루트 페이지 -> 게시글 관리 페이지 Forwarding")
     @Test
     void givenNothing_whenRequestingRootView_thenForwardsToArticleManagementView() throws Exception {


### PR DESCRIPTION
로그인 기능에 따른 서비스와 컨트롤러를 구현한다.

- 회원 계정에서 권한은 영어가 아닌 한글로 변환해 뷰에 전달한다.
`AdminAccountResponse`에서
`dto.roleTypes().stream().map(RoleType::getDescription).collect(Collectors.joining(", "))`
이런 식으로 description을 가져와 ,를 기준으로 조인한다.
결과에는 관리자, 운영자 등으로 나오게 된다.

- 어드민 회원 게시판을 보기 위해 jsGrid 플러그인을 사용했다.
- `members.th.xml`에서 csrf헤더, csrf토큰을 추가해 권한 설정을 한다.