### PR TITLE
[Development] - 부가 기능 - 방문자 수 집계

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/controller/advice/VisitCounterControllerAdvice.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/advice/VisitCounterControllerAdvice.java
@@ -1,0 +1,18 @@
+package com.fastcampus.projectboardadmin.controller.advice;
+
+import com.fastcampus.projectboardadmin.service.VisitCounterService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@RequiredArgsConstructor
+@ControllerAdvice
+public class VisitCounterControllerAdvice {
+
+    private final VisitCounterService visitCounterService;
+
+    @ModelAttribute("visitCount")
+    public Long visitCount() {
+        return visitCounterService.visitCount();
+    }
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/service/VisitCounterService.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/service/VisitCounterService.java
@@ -1,0 +1,40 @@
+package com.fastcampus.projectboardadmin.service;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class VisitCounterService {
+
+    private final MeterRegistry meterRegistry;
+
+    private static final List<String> viewEndPoints = List.of(
+            "/management/articles",
+            "/management/article-comments",
+            "/management/user-accounts",
+            "/admin/members"
+    );
+
+    public long visitCount() {
+        long sum;
+
+        try {
+            sum = meterRegistry.get("http.server.requests")
+                    .timers()
+                    .stream()
+                    .filter(timer -> viewEndPoints.contains(timer.getId().getTag("uri")))
+                    .mapToLong(Timer::count)
+                    .sum();
+        } catch (MeterNotFoundException e) {
+            sum = 0L;
+        }
+
+        return sum;
+    }
+}

--- a/src/main/resources/templates/layouts/layout-left-aside.html
+++ b/src/main/resources/templates/layouts/layout-left-aside.html
@@ -83,6 +83,15 @@
           </ul>
         </li>
       </ul>
+      <div class="small-box bg-info">
+        <div class="inner">
+          <h3 id="visit-count">0</h3>
+          <p>방문 횟수</p>
+        </div>
+        <div class="icon">
+          <i class="fas fa-chart-pie"></i>
+        </div>
+      </div>
     </nav>
     <!--/* /.sidebar-menu */-->
   </div>

--- a/src/main/resources/templates/layouts/layout-left-aside.th.xml
+++ b/src/main/resources/templates/layouts/layout-left-aside.th.xml
@@ -24,4 +24,5 @@
             th:href="@{/admin/members}"
             th:classappend="${#request.requestURI.equals('/admin/members')} ? 'active'"
     />
+    <attr sel="#visit-count" th:text="${visitCount}" />
 </thlogic>

--- a/src/test/java/com/fastcampus/projectboardadmin/config/GlobalControllerConfig.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/config/GlobalControllerConfig.java
@@ -1,0 +1,20 @@
+package com.fastcampus.projectboardadmin.config;
+
+import com.fastcampus.projectboardadmin.service.VisitCounterService;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import static org.mockito.BDDMockito.given;
+
+@TestConfiguration
+public class GlobalControllerConfig {
+
+    @MockBean private VisitCounterService visitCounterService;
+
+    @BeforeTestMethod
+    public void securitySetup() {
+        given(visitCounterService.visitCount()).willReturn(0L);
+
+    }
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/AdminAccountControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/AdminAccountControllerTest.java
@@ -1,5 +1,6 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import com.fastcampus.projectboardadmin.config.GlobalControllerConfig;
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
@@ -27,7 +28,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("Controller - 어드민 유저")
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, GlobalControllerConfig.class})
 @WebMvcTest(AdminAccountController.class)
 class AdminAccountControllerTest {
 

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -1,5 +1,6 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import com.fastcampus.projectboardadmin.config.GlobalControllerConfig;
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
 import com.fastcampus.projectboardadmin.config.TestSecurityConfig;
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
@@ -27,7 +28,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("컨트롤러 - 댓글 관리")
-@Import(TestSecurityConfig.class)
+@Import({TestSecurityConfig.class, GlobalControllerConfig.class})
 @WebMvcTest(ArticleCommentManagementController.class)
 class ArticleCommentManagementControllerTest {
 

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -1,5 +1,6 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import com.fastcampus.projectboardadmin.config.GlobalControllerConfig;
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
 import com.fastcampus.projectboardadmin.config.TestSecurityConfig;
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
@@ -26,7 +27,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("컨트롤러 - 게시글 관리")
-@Import(TestSecurityConfig.class)
+@Import({TestSecurityConfig.class, GlobalControllerConfig.class})
 @WebMvcTest(ArticleManagementController.class)
 class ArticleManagementControllerTest {
 

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/MainControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/MainControllerTest.java
@@ -1,5 +1,6 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import com.fastcampus.projectboardadmin.config.GlobalControllerConfig;
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
 import com.fastcampus.projectboardadmin.config.TestSecurityConfig;
 import org.junit.jupiter.api.DisplayName;
@@ -14,7 +15,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View 루트 컨트롤러")
-@Import(TestSecurityConfig.class)
+@Import({TestSecurityConfig.class, GlobalControllerConfig.class})
 @WebMvcTest(MainController.class)
 class MainControllerTest {
 

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
@@ -1,5 +1,6 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import com.fastcampus.projectboardadmin.config.GlobalControllerConfig;
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
 import com.fastcampus.projectboardadmin.config.TestSecurityConfig;
 import com.fastcampus.projectboardadmin.dto.UserAccountDto;
@@ -23,7 +24,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("컨트롤러 - 회원 관리")
-@Import(TestSecurityConfig.class)
+@Import({TestSecurityConfig.class, GlobalControllerConfig.class})
 @WebMvcTest(UserAccountManagementController.class)
 class UserAccountManagementControllerTest {
 


### PR DESCRIPTION
페이지 조회수를 집계해 하루에 도구를 사용하는 사용량을 가늠하는 지표로 활용한다. 
- spring actuator의 지표 수집 기능 활용

`@ControllerAdvice`
- 전역 컨트롤러 예외 처리를 담당하는 클래스에 지정하는데 사용된다.
- 방문자 수를 계산하는 기능을 뷰에서 보일 수 있게 모델에 추가한다.

`MeterRegistry`
- 메트릭 데이터를 수집하고 관리하는 역할
- 애플리케이션의 성능과 상태를 모니터링하고 문제를 식별하는 데 도움을 준다.
- 메트릭을 조회해 방문자 수를 계산하는 기능에 활용했다.

`.filter(timer -> viewEndPoints.contains(timer.getId().getTag("uri")))`
- 스트림의 각 타이머 메트릭을 필터링하여 `viewEndPoints`에있는 URI 값을 가진 메트릭만을 선택합니다
- 특정 URI와 관련된 요청만을 고려합니다.